### PR TITLE
Small usability improvements.

### DIFF
--- a/src/controllers/AppController.vala
+++ b/src/controllers/AppController.vala
@@ -48,6 +48,24 @@ namespace App.Controllers {
                 app_view.update_tags ();
             });
 
+            // Focus the search_entry on ctrl+l (like browser)
+            window.key_press_event.connect ((ev) => {
+                var ctrl = (ev.state == Gdk.ModifierType.CONTROL_MASK);
+                if (ctrl && ev.keyval == 108)
+                    headerbar.search_entry.grab_focus_without_selecting ();
+                return false;
+            });
+
+            // Generate gitignore on ctrl+enter only if button is sensitive
+            headerbar.search_entry.key_press_event.connect ((ev) => {
+                var ctrl = (ev.state == Gdk.ModifierType.CONTROL_MASK);
+                if (ctrl && ev.keyval == 65293)
+                if (app_view.generate_gitignore_button.get_sensitive()) {
+                    app_view.generate_gitignore_button.clicked();
+                }
+                return false;
+            });
+
             window.add (app_view);
             window.set_titlebar (headerbar);
             application.add_window (window);

--- a/src/views/AppView.vala
+++ b/src/views/AppView.vala
@@ -26,7 +26,7 @@ namespace App.Views {
 
         private App.Views.GitignoreView gitignore_view;
 
-        private App.Widgets.Button generate_gitignore_button;
+        public App.Widgets.Button generate_gitignore_button;
         private Gtk.Button copy_button;
         private Gtk.Button save_button;
 

--- a/src/widgets/EntryCompletion.vala
+++ b/src/widgets/EntryCompletion.vala
@@ -24,7 +24,7 @@ namespace App.Widgets {
         public EntryCompletion () {
             Object (
                 inline_selection: true,
-                popup_single_match: false
+                popup_single_match: true
             );
 
             var data = App.Utils.DataUtils.DATA;

--- a/src/widgets/HeaderBar.vala
+++ b/src/widgets/HeaderBar.vala
@@ -50,7 +50,7 @@ namespace App.Widgets {
                 list.add (data_set[i]);
             }
 
-            search_entry.activate.connect (() => {
+            entry_completion.match_selected.connect (() => {
                 string[] data = settings.get_strv ("selected-langs");
 
                 if (data.length == 0) {
@@ -80,6 +80,9 @@ namespace App.Widgets {
                 }
 
                 changed ();
+
+                search_entry.text = "";
+                return true;
             });
 
             var window_settings = Gtk.Settings.get_default ();


### PR DESCRIPTION
I changed a few different small things to make the application easier to use.

### Search bar usability

- Languages are selected with a single "enter" press instead of two
- The search entry is cleared so you can quickly add another

### Fixed search entry completion bug

- When you would type a specific language such as "node" or "python",
  there wouldn't be any languages to choose from. This was fixed by
  simply setting "popup_single_match" to true. This allows you to select
  single matches.

### Added keyboard shortcuts for productivity.

- You can now focus the search entry on application start by using the
  "Ctrl+L" keyboard shortcut. This behaviour is expected because it is
  often used in the browser.
- You can generate the gitignore by pressing "Ctrl+Enter" inside of the
  search entry box. It respects the generate button's visibility status
  and only fires if the button is clickable.